### PR TITLE
dosnames: Replace rindex with strrchr

### DIFF
--- a/src/dosnames.c
+++ b/src/dosnames.c
@@ -589,7 +589,7 @@ char *dos_unix_path_fcb(int addr, int force)
 static struct dos_file_list *find_first_file(char *fspec)
 {
     // Now, separate the path to the spec
-    char *glob, *unixpath, *p = rindex(fspec, '/');
+    char *glob, *unixpath, *p = strrchr(fspec, '/');
     if(!p)
     {
         glob = fspec;


### PR DESCRIPTION
`rindex` is deprecated:

```
CONFORMING TO
       4.3BSD; marked as LEGACY in POSIX.1-2001.  POSIX.1-2008 removes the specifications of index() and rindex(), recommending strchr(3) and strrchr(3) instead.
```

The `rindex` and `strrchr` functions are identical:

```
       char *strrchr(const char *s, int c);
       The strrchr() function returns a pointer to the last occurrence of the character c in the string s.
```

```
       char *rindex(const char *s, int c);
       The rindex() function returns a pointer to the last occurrence of the character c in the string s.
```
