### PR TITLE
OpenBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC=cc
 CFLAGS=-O3 -flto -Wall -g -Werror=implicit-function-declaration -Werror=int-conversion
 LDLIBS=-lm
 INSTALL=install

--- a/src/main.c
+++ b/src/main.c
@@ -14,6 +14,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <signal.h>
 #include <string.h>
 #include <sys/time.h>
 #include <sys/wait.h>


### PR DESCRIPTION
simply two changes needed
- use default compiler
- add #include <signal.h>
On modern Linux, signal(2) works as BSD signal (not SysV). So simply add missed header.