### PR TITLE
fix warning due to printf flags for int64

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -66,7 +66,7 @@ static long get_timer_clock(void)
 static uint16_t get_actual_timer(struct i8253_timer *t)
 {
     uint64_t elapsed = get_timer_clock() - t->load_time;
-    debug(debug_int, "timer elapsed: %ld\n", elapsed);
+    debug(debug_int, "timer elapsed: %lld\n", elapsed);
     switch(t->op_mode & 7)
     {
     case 2: // RATE GENERATOR


### PR DESCRIPTION
It is a suggested small fix on timer.c. %ld vs %lld