### PR TITLE
fix "non-void function does not return a value" warning

### DIFF
--- a/src/dis.c
+++ b/src/dis.c
@@ -823,4 +823,6 @@ const char *disa(const uint8_t *ip, uint16_t reg_ip, int segment_override)
     case 0xfe: return decode_b(ip, table_fe[(ip[1] & 0x38) >> 3], segment_override);
     case 0xff: return decode_ff(ip, segment_override);
     }
+    /*NOTREACHED*/
+    return show(ip, "bug?");
 }

--- a/src/dis.c
+++ b/src/dis.c
@@ -823,6 +823,5 @@ const char *disa(const uint8_t *ip, uint16_t reg_ip, int segment_override)
     case 0xfe: return decode_b(ip, table_fe[(ip[1] & 0x38) >> 3], segment_override);
     case 0xff: return decode_ff(ip, segment_override);
     }
-    /*NOTREACHED*/
-    return show(ip, "bug?");
+    __builtin_unreachable();
 }


### PR DESCRIPTION
I think this might not be needed, but clang-13 on OpenBSD-7.4/amd64 says warning so fixed.