### PR TITLE
Support IBM AIX, illumos, and Oracle Solaris 11

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,8 @@
-CC=cc
-CFLAGS=-O3 -flto -Wall -g -Werror=implicit-function-declaration -Werror=int-conversion
-LDLIBS=-lm
-INSTALL=install
-PREFIX=/usr
+CC?=cc
+CFLAGS?=-O3 -flto -Wall -g -Werror=implicit-function-declaration -Werror=int-conversion
+LDLIBS?=-lm
+INSTALL?=install
+PREFIX?=/usr
 
 OBJS=\
  cpu.o\
@@ -18,7 +18,7 @@ OBJS=\
  utils.o\
  video.o\
 
-
+.PHONY: all
 all: obj emu2
 
 emu2: $(OBJS:%=obj/%)
@@ -29,31 +29,36 @@ obj/%.o: src/%.c
 obj:
 	mkdir -p obj
 
-clean:
-	rm -f $(OBJS:%=obj/%)
+.PHONY: clean distclean
+clean distclean:
+	rm -rf obj
 	rm -f emu2
-	test -d obj && rmdir obj || true
 
+.PHONY: install
 install: emu2
 	$(INSTALL) -d $(DESTDIR)${PREFIX}/bin
 	$(INSTALL) -s emu2 $(DESTDIR)${PREFIX}/bin
 
+.PHONY: uninstall
 uninstall:
 	rm -f $(DESTDIR)${PREFIX}/bin/emu2
 
 # Generated with gcc -MM src/*.c
 obj/codepage.o: src/codepage.c src/codepage.h src/dbg.h src/env.h
 obj/cpu.o: src/cpu.c src/cpu.h src/dbg.h src/dis.h src/emu.h
-obj/dbg.o: src/dbg.c src/dbg.h src/env.h
+obj/dbg.o: src/dbg.c src/dbg.h src/env.h src/version.h
 obj/dis.o: src/dis.c src/dis.h src/emu.h
-obj/dos.o: src/dos.c src/codepage.h src/dos.h src/dbg.h src/dosnames.h \
- src/emu.h src/env.h src/keyb.h src/loader.h src/timer.h src/utils.h \
- src/video.h
-obj/dosnames.o: src/dosnames.c src/dbg.h src/dosnames.h src/emu.h src/env.h
-obj/keyb.o: src/keyb.c src/keyb.h src/dbg.h src/emu.h src/codepage.h
+obj/dos.o: src/dos.c src/dos.h src/codepage.h src/dbg.h \
+ src/dosnames.h src/emu.h src/env.h src/keyb.h src/loader.h \
+ src/timer.h src/utils.h src/video.h
+obj/dosnames.o: src/dosnames.c src/dosnames.h src/dbg.h src/emu.h \
+ src/env.h
+obj/keyb.o: src/keyb.c src/keyb.h src/codepage.h src/dbg.h src/emu.h \
+ src/os.h
 obj/loader.o: src/loader.c src/loader.h src/dbg.h src/emu.h
 obj/main.o: src/main.c src/dbg.h src/dos.h src/dosnames.h src/emu.h \
  src/keyb.h src/timer.h src/video.h
-obj/timer.o: src/timer.c src/dbg.h src/timer.h src/emu.h
+obj/timer.o: src/timer.c src/timer.h src/dbg.h src/emu.h
 obj/utils.o: src/utils.c src/utils.h src/dbg.h
-obj/video.o: src/video.c src/video.h src/dbg.h src/emu.h src/codepage.h
+obj/video.o: src/video.c src/video.h src/codepage.h src/dbg.h \
+ src/emu.h src/env.h src/keyb.h

--- a/src/keyb.c
+++ b/src/keyb.c
@@ -2,6 +2,7 @@
 #include "codepage.h"
 #include "dbg.h"
 #include "emu.h"
+#include "os.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -377,7 +378,15 @@ static void set_raw_term(int raw)
         struct termios newattr;
         tcgetattr(tty_fd, &oldattr);
         newattr = oldattr;
+#if defined(NO_CFMAKERAW)
+        newattr.c_iflag &= ~(IMAXBEL|IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL|IXON);
+        newattr.c_oflag &= ~OPOST;
+        newattr.c_lflag &= ~(ECHO|ECHONL|ICANON|ISIG|IEXTEN);
+        newattr.c_cflag &= ~(CSIZE|PARENB);
+        newattr.c_cflag |= CS8;
+#else
         cfmakeraw(&newattr);
+#endif
         newattr.c_cc[VMIN] = 0;
         newattr.c_cc[VTIME] = 0;
         tcsetattr(tty_fd, TCSANOW, &newattr);

--- a/src/main.c
+++ b/src/main.c
@@ -320,13 +320,19 @@ int main(int argc, char **argv)
     else
         init_dos(argc - 1, argv + 1);
 
-    signal(SIGALRM, timer_alarm);
+    struct sigaction timer_action, exit_action;
+    exit_action.sa_handler = exit_handler;
+    timer_action.sa_handler = timer_alarm;
+    sigemptyset(&exit_action.sa_mask);
+    sigemptyset(&timer_action.sa_mask);
+    exit_action.sa_flags = timer_action.sa_flags = 0;
+    sigaction(SIGALRM, &timer_action, NULL);
     // Install an exit handler to allow exit functions to run
-    signal(SIGHUP, exit_handler);
-    signal(SIGINT, exit_handler);
-    signal(SIGQUIT, exit_handler);
-    signal(SIGPIPE, exit_handler);
-    signal(SIGTERM, exit_handler);
+    sigaction(SIGHUP, &exit_action, NULL);
+    sigaction(SIGINT, &exit_action, NULL);
+    sigaction(SIGQUIT, &exit_action, NULL);
+    sigaction(SIGPIPE, &exit_action, NULL);
+    sigaction(SIGTERM, &exit_action, NULL);
     struct itimerval itv;
     itv.it_interval.tv_sec = 0;
     itv.it_interval.tv_usec = 54925;

--- a/src/os.h
+++ b/src/os.h
@@ -1,0 +1,11 @@
+#ifndef OS_H_INCLUDED
+#define OS_H_INCLUDED
+
+/* Platforms which are missing cfmakeraw() */
+#if defined(__sun)
+# if !defined(NO_CFMAKERAW)
+#  define NO_CFMAKERAW
+# endif
+#endif
+
+#endif


### PR DESCRIPTION
Add support for **IBM AIX**, **illumos**, and **Oracle Solaris 11**:
  - Allow overriding `Makefile` variables from environment
  - Workaround lack of `cfmakeraw` on **Solaris**/**illumos** platforms
  - Use `sigaction` instead of `signal`
  - Rename `Makefile` to `GNUmakefile` (as it depends on GNU Make)
    - Avoids possible confusion on AIX, Solaris, and BSD systems
  - Regenerate dependencies

---

* Tested with **IBM XL C/C++ V16.1.0.19**, **IBM Open XL C/C++ V17.1.2.11**, and **GNU GCC 12.3.0** on **IBM AIX 7.2** and **AIX 7.3** with **GNU Make 4.4.1**:
  ```sh
  env CC="/opt/IBM/xlC/16.1.0/bin/xlc" \
    CFLAGS="-q64 -O3" LDFLAGS="-Wl,-b64" gmake
  ```
  ```sh
  env CC="/opt/IBM/openxlC/17.1.2/bin/ibm-clang" \
    CFLAGS="-m64 -O3 -flto" LDFLAGS="-Wl,-b64" gmake
  ```
  ```sh
  env CC="gcc-12" \
    CFLAGS="-maix64 -O3" LDFLAGS="-Wl,-b64" gmake
  ```

* Tested on **Oracle Solaris 11.4** with **Oracle Developer Studio 12.6 (2022/10/24)** and **GNU Make 4.2.1**:
  ```sh
  env CC="/opt/developerstudio12.6/bin/suncc" \
    CFLAGS="-O3 -m64" gmake
  ```

* Tested on **illumos** (*OpenIndiana*) with **GNU GCC 13.3.0** and **GNU Make 4.3**:
  ```sh
  env CC="gcc" gmake
  ```