### PR TITLE
Fix potential warning; don't check if an unsigned type is >= 0

### DIFF
--- a/src/dbg.c
+++ b/src/dbg.c
@@ -97,7 +97,7 @@ void init_debug(const char *base)
 
 int debug_active(enum debug_type dt)
 {
-    if(dt >= 0 && dt < debug_MAX)
+    if(dt < debug_MAX)
         return debug_files[dt] != 0;
     else
         return 0;


### PR DESCRIPTION
The enum `debug_type` is unsigned since all the enumerated values can be represented by an unsigned integer, so the check is redundant.

```c
"src/dbg.c", line 100: warning: pointless comparison of unsigned integer with zero  [unsigned_compare_with_zero]
      if(dt >= 0 && dt < debug_MAX)
         ^
```