### PR TITLE
Eliminate unused assignment in run_emulator function

### DIFF
--- a/src/dos.c
+++ b/src/dos.c
@@ -792,7 +792,7 @@ static int run_emulator(char *file, const char *prgname, char *cmdline, char *en
     else if(pid != 0)
     {
         int status;
-        while((waitpid(pid, &status, 0)) == -1)
+        while(waitpid(pid, &status, 0) == -1)
         {
             if(errno != EINTR)
             {

--- a/src/dos.c
+++ b/src/dos.c
@@ -791,8 +791,8 @@ static int run_emulator(char *file, const char *prgname, char *cmdline, char *en
         print_error("fork error, %s\n", strerror(errno));
     else if(pid != 0)
     {
-        int ret, status;
-        while((ret = waitpid(pid, &status, 0)) == -1)
+        int status;
+        while((waitpid(pid, &status, 0)) == -1)
         {
             if(errno != EINTR)
             {


### PR DESCRIPTION
Eliminate unused assignment in run_emulator function