### PR TITLE
Add '-v' command-line argument to show version

### DIFF
--- a/src/dbg.c
+++ b/src/dbg.c
@@ -8,10 +8,22 @@
 
 char *prog_name;
 
+void print_version(int quit)
+{
+    printf("EMU2 - Simple x86 + DOS Emulator, version " EMU2_VERSION
+#ifdef __DATE__
+           "  (Compiled " __DATE__ ")"
+#endif
+           "\n");
+
+    if (quit)
+        exit(EXIT_SUCCESS);
+}
+
 void print_usage(void)
 {
-    printf("EMU2 - Simple x86 + DOS Emulator, version " EMU2_VERSION "\n"
-           "\n"
+    print_version(0);
+    printf("\n"
            "Usage: %s [options] <prog.exe> [args...] [-- environment vars]\n"
            "\n"
            "Options (processed before program name):\n"

--- a/src/dbg.h
+++ b/src/dbg.h
@@ -4,6 +4,7 @@
 
 extern char *prog_name;
 
+void print_version(int quit);
 void print_usage(void);
 void print_usage_error(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void print_error(const char *format, ...) __attribute__((format(printf, 1, 2)));

--- a/src/main.c
+++ b/src/main.c
@@ -250,6 +250,8 @@ int main(int argc, char **argv)
         {
         case 'h':
             print_usage();
+        case 'v':
+            print_version(1);
         case 'b':
             bin_load_addr = strtol(opt, &ep, 0);
             if(*ep || bin_load_addr < 0 || bin_load_addr > 0xFFFF0)


### PR DESCRIPTION
* Add '-v' command-line argument to show version and also add the date the binary was compiled to the output.

I was losing track of which build I was using so I came up with this.  Feel free to close if you don’t like it or want it.