### PR TITLE
Silence Clang’s `-Wmissing-variable-declarations` warnings

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -9,11 +9,11 @@
 // Main Memory (17 * 64K, no overlap)
 uint8_t memory[0x110000];
 // First MCB
-uint16_t mcb_start = 0x40;
+static uint16_t mcb_start = 0x40;
 // MCB allocation strategy
-uint8_t mcb_alloc_st = 0;
+static uint8_t mcb_alloc_st = 0;
 // PSP (Program Segment Prefix) location
-uint16_t current_PSP;
+static uint16_t current_PSP;
 
 // MS-DOS version to emulate on FCB command line parsing.
 #define FCB_PARSE_DOS (3)


### PR DESCRIPTION
Silence Clang’s `-Wmissing-variable-declarations` warnings:

```c
src/loader.c:12:10: warning: no previous extern declaration for non-static variable 'mcb_start' [-Wmissing-variable-declarations]
   12 | uint16_t mcb_start = 0x40;
      |          ^
```
```c
src/loader.c:14:9: warning: no previous extern declaration for non-static variable 'mcb_alloc_st' [-Wmissing-variable-declarations]
   14 | uint8_t mcb_alloc_st = 0;
      |         ^
```
```c
src/loader.c:16:10: warning: no previous extern declaration for non-static variable 'current_PSP' [-Wmissing-variable-declarations]
   16 | uint16_t current_PSP;
      |          ^
```