### PR TITLE
Silence Clang’s `-Wmissing-prototypes` warnings

### DIFF
--- a/src/keyb.c
+++ b/src/keyb.c
@@ -30,7 +30,7 @@ static void update_bios_state(void)
 }
 
 // Update keyboard buffer pointer
-void keyb_read_buffer(void)
+static void keyb_read_buffer(void)
 {
     int ptr = (memory[0x41A] - 0x1E) & 0x1F;
     memory[0x41A] = 0x1E + ((ptr + 2) & 0x1F);

--- a/src/loader.c
+++ b/src/loader.c
@@ -490,13 +490,13 @@ static int mcb_grow_max(int mcb)
     return total;
 }
 
-void mcb_free(int mcb)
+static void mcb_free(int mcb)
 {
     mcb_set_owner(mcb, 0);
     mcb_grow_max(mcb);
 }
 
-int mcb_alloc_new(int size, int owner, int *max)
+static int mcb_alloc_new(int size, int owner, int *max)
 {
     int mcb = mcb_start;
     int stg = mcb_alloc_st & 0x3F;
@@ -544,7 +544,7 @@ int mcb_alloc_new(int size, int owner, int *max)
     }
 }
 
-int mcb_resize(int mcb, int size)
+static int mcb_resize(int mcb, int size)
 {
     debug(debug_dos, "\tmcb_resize: mcb:$%04X new size:$%04X\n", mcb, size);
     if(mcb_size(mcb) == size) // Do nothing!


### PR DESCRIPTION
Silence Clang’s `-Wmissing-prototypes` warnings:

```c
src/loader.c:493:6: warning: no previous prototype for function 'mcb_free' [-Wmissing-prototypes]
  493 | void mcb_free(int mcb)
      |      ^
```
```c
src/loader.c:499:5: warning: no previous prototype for function 'mcb_alloc_new' [-Wmissing-prototypes]
  499 | int mcb_alloc_new(int size, int owner, int *max)
      |     ^
```
```c
src/loader.c:547:5: warning: no previous prototype for function 'mcb_resize' [-Wmissing-prototypes]
  547 | int mcb_resize(int mcb, int size)
      |     ^
```
```c
src/keyb.c:33:6: warning: no previous prototype for function 'keyb_read_buffer' [-Wmissing-prototypes]
   33 | void keyb_read_buffer(void)
      |      ^
```