### PR TITLE
Silence Clang's `-Wunreachable-code` warnings

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -56,7 +56,7 @@ static void cmdline_to_fcb(const char *cmd_line, uint8_t *fcb1, uint8_t *fcb2)
     while(cmd_line[i])
     {
         int c = cmd_line[i];
-        if(FCB_PARSE_DOS == 1 && c == ';')
+        if(FCB_PARSE_DOS == (1) && c == ';')
         {
             c = '+';
         }
@@ -144,14 +144,14 @@ static void cmdline_to_fcb(const char *cmd_line, uint8_t *fcb1, uint8_t *fcb2)
                 }
                 break;
             case '+':
-                if(FCB_PARSE_DOS == 1)
+                if(FCB_PARSE_DOS == (1))
                 {
                     offset = fcb2 + 1;
                     state = FCB_PARSE_SEP_PLUS;
                     break;
                 }
             case ':':
-                if(FCB_PARSE_DOS == 1)
+                if(FCB_PARSE_DOS == (1))
                 {
                     offset = fcb2 + 1;
                     state = FCB_PARSE_FCB2;
@@ -190,7 +190,7 @@ static void cmdline_to_fcb(const char *cmd_line, uint8_t *fcb1, uint8_t *fcb2)
             switch(c)
             {
             case '.':
-                if(FCB_PARSE_DOS == 1)
+                if(FCB_PARSE_DOS == (1))
                 {
                     offset = fcb2 + 9;
                     state = FCB_PARSE_FCB2_EXT;
@@ -209,14 +209,14 @@ static void cmdline_to_fcb(const char *cmd_line, uint8_t *fcb1, uint8_t *fcb2)
                 }
                 break;
             case '+':
-                if(FCB_PARSE_DOS == 1)
+                if(FCB_PARSE_DOS == (1))
                 {
                     offset = fcb2 + 1;
                     state = FCB_PARSE_SEP_PLUS;
                     break;
                 }
             case ':':
-                if(FCB_PARSE_DOS == 1)
+                if(FCB_PARSE_DOS == (1))
                 {
                     offset = fcb2 + 1;
                     state = FCB_PARSE_FCB2;


### PR DESCRIPTION
Silence Clang's `-Wunreachable-code` warnings:

```c
src/loader.c:61:17: warning: code will never be executed [-Wunreachable-code]
   61 |             c = '+';
```
```c
src/loader.c:149:30: warning: code will never be executed [-Wunreachable-code]
  149 |                     offset = fcb2 + 1;
```
```c
src/loader.c:156:30: warning: code will never be executed [-Wunreachable-code]
  156 |                     offset = fcb2 + 1;
```
```c
src/loader.c:195:30: warning: code will never be executed [-Wunreachable-code]
  195 |                     offset = fcb2 + 9;
```
```c
src/loader.c:214:30: warning: code will never be executed [-Wunreachable-code]
  214 |                     offset = fcb2 + 1;
```
```c
src/loader.c:221:30: warning: code will never be executed [-Wunreachable-code]
  221 |                     offset = fcb2 + 1;
```