### PR TITLE
Silence Clang’s `-Wstrict-prototypes` warnings

### DIFF
--- a/src/cpu.c
+++ b/src/cpu.c
@@ -2575,19 +2575,19 @@ void cpuSetDS(unsigned v) { sregs[DS] = v; }
 void cpuSetIP(unsigned v) { ip = v; }
 
 // Get CPU registers from outside
-unsigned cpuGetAX() { return wregs[AX]; }
-unsigned cpuGetCX() { return wregs[CX]; }
-unsigned cpuGetDX() { return wregs[DX]; }
-unsigned cpuGetBX() { return wregs[BX]; }
-unsigned cpuGetSP() { return wregs[SP]; }
-unsigned cpuGetBP() { return wregs[BP]; }
-unsigned cpuGetSI() { return wregs[SI]; }
-unsigned cpuGetDI() { return wregs[DI]; }
-unsigned cpuGetES() { return sregs[ES]; }
-unsigned cpuGetCS() { return sregs[CS]; }
-unsigned cpuGetSS() { return sregs[SS]; }
-unsigned cpuGetDS() { return sregs[DS]; }
-unsigned cpuGetIP() { return ip; }
+unsigned cpuGetAX(void) { return wregs[AX]; }
+unsigned cpuGetCX(void) { return wregs[CX]; }
+unsigned cpuGetDX(void) { return wregs[DX]; }
+unsigned cpuGetBX(void) { return wregs[BX]; }
+unsigned cpuGetSP(void) { return wregs[SP]; }
+unsigned cpuGetBP(void) { return wregs[BP]; }
+unsigned cpuGetSI(void) { return wregs[SI]; }
+unsigned cpuGetDI(void) { return wregs[DI]; }
+unsigned cpuGetES(void) { return sregs[ES]; }
+unsigned cpuGetCS(void) { return sregs[CS]; }
+unsigned cpuGetSS(void) { return sregs[SS]; }
+unsigned cpuGetDS(void) { return sregs[DS]; }
+unsigned cpuGetIP(void) { return ip; }
 
 // Address of flags in stack when in interrupt handler
 static uint8_t *flagAddr(void)

--- a/src/dos.c
+++ b/src/dos.c
@@ -32,7 +32,7 @@ static uint32_t dos_sysvars;
 static uint32_t dos_append;
 
 // Returns "APPEND" path, if activated:
-static const char *append_path()
+static const char *append_path(void)
 {
     return (memory[dos_append] & 0x01) ? ((char *)memory + dos_append + 2) : 0;
 }
@@ -272,7 +272,7 @@ static int get_fcb_handle(void)
     return get16(0x18 + get_fcb());
 }
 
-static void dos_show_fcb()
+static void dos_show_fcb(void)
 {
     if(!debug_active(debug_dos))
         return;
@@ -856,7 +856,7 @@ static int run_emulator(char *file, const char *prgname, char *cmdline, char *en
 }
 
 // DOS exit
-void intr20()
+void intr20(void)
 {
     exit(0);
 }
@@ -884,7 +884,7 @@ static void char_input(int brk)
 }
 
 // Returns true if a character to read is pending
-static int char_pending()
+static int char_pending(void)
 {
     return (inp_last_key != 0) || kbhit();
 }
@@ -1009,7 +1009,7 @@ static void intr21_debug(void)
 
 // DOS int 2f
 // Static set of functions used for DOS devices/extensions and TSR installation checks
-void intr2f()
+void intr2f(void)
 {
     debug(debug_int, "D-2F%04X: BX=%04X\n", cpuGetAX(), cpuGetBX());
     unsigned ax = cpuGetAX();
@@ -1041,7 +1041,7 @@ void intr2f()
 }
 
 // DOS int 21
-void intr21()
+void intr21(void)
 {
     // Check CP/M call, INT 21h from address 0x000C0
     if(cpuGetAddress(cpuGetStack(2), cpuGetStack(0)) == 0xC2)
@@ -2124,7 +2124,7 @@ void intr21()
 }
 
 // DOS int 22 - TERMINATE ADDRESS
-void intr22()
+void intr22(void)
 {
     debug(debug_dos, "D-22: TERMINATE HANDLER CALLED\n");
     // If we reached here, we must terminate now

--- a/src/keyb.c
+++ b/src/keyb.c
@@ -575,7 +575,7 @@ void keyb_handle_irq(void)
 }
 
 // BIOS keyboards handler
-void intr16()
+void intr16(void)
 {
     debug(debug_int, "B-16%04X: BX=%04X\n", cpuGetAX(), cpuGetBX());
     unsigned ax = cpuGetAX();

--- a/src/video.c
+++ b/src/video.c
@@ -116,7 +116,7 @@ static void reload_posxy(int page)
     vid_posy[page] = memory[0x451 + page * 2];
 }
 
-static void reload_posxy_all()
+static void reload_posxy_all(void)
 {
     for(int i = 0; i < 8; i++)
     {
@@ -629,7 +629,7 @@ void video_putch(char ch)
 }
 
 // VIDEO int
-void intr10()
+void intr10(void)
 {
     debug(debug_int, "V-10%04X: BX=%04X\n", cpuGetAX(), cpuGetBX());
     debug(debug_video, "V-10%04X: BX=%04X CX=%04X DX=%04X\n", cpuGetAX(), cpuGetBX(),


### PR DESCRIPTION
Silence Clang’s `-Wstrict-prototypes` warnings, which also quiets warnings produced by *Oracle Developer Studio*’s compiler and `lint` tool on Solaris.

```c
src/video.c:632:12: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/video.c:119:29: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/keyb.c:578:12: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/dos.c:2127:12: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/dos.c:1044:12: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/dos.c:1012:12: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/dos.c:887:24: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/dos.c:859:12: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/dos.c:275:25: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/dos.c:35:31: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2590:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2589:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2588:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2587:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2586:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2585:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2584:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2583:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2582:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2581:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2580:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2579:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
src/cpu.c:2578:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
```