### PR TITLE
Silence Clang’s extended `-Wformat` warnings

### DIFF
--- a/src/dis.c
+++ b/src/dis.c
@@ -60,7 +60,7 @@ static char *get_mem(unsigned ModRM, const uint8_t *ip, const char *rg[],
         }
         else
             ch = '+';
-        sprintf(buffer, "%s%s[%s%c%02X]", cast, seg_names[seg_over], IXREG, ch, num);
+        sprintf(buffer, "%s%s[%s%c%02X]", cast, seg_names[seg_over], IXREG, ch, (unsigned)num);
         break;
     case 0x80:
         if((num = (ip[2] * 256 + ip[1])) > 0x7fff)
@@ -70,7 +70,7 @@ static char *get_mem(unsigned ModRM, const uint8_t *ip, const char *rg[],
         }
         else
             ch = '+';
-        sprintf(buffer, "%s%s[%s%c%04X]", cast, seg_names[seg_over], IXREG, ch, num);
+        sprintf(buffer, "%s%s[%s%c%04X]", cast, seg_names[seg_over], IXREG, ch, (unsigned)num);
         break;
     case 0xc0:
         strcpy(buffer, rg[ModRM & 7]);
@@ -137,7 +137,8 @@ static const char *decode_jump8(const uint8_t *ip, const char *ins, uint16_t reg
 static const char *decode_far(const uint8_t *ip, const char *ins)
 {
     fillbytes(ip, 5);
-    sprintf(IPOS, "%-7s %04X:%04X", ins, ip[4] * 256 + ip[3], ip[2] * 256 + ip[1]);
+    sprintf(IPOS, "%-7s %04X:%04X", ins,
+            (unsigned)(ip[4] * 256 + ip[3]), (unsigned)(ip[2] * 256 + ip[1]));
     return buf;
 }
 
@@ -374,7 +375,7 @@ static const char *decode_imul_b(const uint8_t *ip, const char *ins, int seg_ove
     fillbytes(ip, 3 + get_mem_len(ModRM));
     sprintf(IPOS, "%-7s %s,%s,%c%02X", ins, WREG,
             get_mem(ModRM, ip + 1, word_reg, "", seg_over), d1 > 0x7F ? '-' : '+',
-            d1 > 0x7F ? 0x100 - d1 : d1);
+            (unsigned)(d1 > 0x7F ? 0x100 - d1 : d1));
     return buf;
 }
 

--- a/src/keyb.c
+++ b/src/keyb.c
@@ -505,7 +505,7 @@ uint8_t keyb_read_port(unsigned port)
 {
     if(queued_key == -1)
         kbhit();
-    debug(debug_int, "keyboard read_port: %02X (key=%04X)\n", port, queued_key);
+    debug(debug_int, "keyboard read_port: %02X (key=%04X)\n", port, (unsigned)queued_key);
     if(port == 0x60)
         return queued_key >> 8;
     else if(port == 0x61)

--- a/src/loader.c
+++ b/src/loader.c
@@ -405,8 +405,8 @@ static void mcb_new(int mcb, int owner, int size, int last)
     memory[mcb * 16 + 0] = last ? 'Z' : 'M';
     put16(mcb * 16 + 1, owner);
     put16(mcb * 16 + 3, size);
-    debug(debug_dos, "\tmcb_new: mcb:$%04X type:%c owner:$%04X size:$%04X\n", mcb,
-          last ? 'Z' : 'M', owner, size);
+    debug(debug_dos, "\tmcb_new: mcb:$%04X type:%c owner:$%04X size:$%04X\n",
+          (unsigned)mcb, last ? 'Z' : 'M', (unsigned)owner, (unsigned)size);
 }
 
 static int mcb_size(int mcb)
@@ -546,7 +546,7 @@ int mcb_alloc_new(int size, int owner, int *max)
 
 int mcb_resize(int mcb, int size)
 {
-    debug(debug_dos, "\tmcb_resize: mcb:$%04X new size:$%04X\n", mcb, size);
+    debug(debug_dos, "\tmcb_resize: mcb:$%04X new size:$%04X\n", (unsigned)mcb, (unsigned)size);
     if(mcb_size(mcb) == size) // Do nothing!
         return size;
     int max = mcb_grow_max(mcb);
@@ -648,7 +648,7 @@ uint16_t create_PSP(const char *cmdline, const char *environment, int env_size,
             debug(debug_dos, "\tenv: '%s'\n", p);
             p += strlen(p) + 1;
         }
-        debug(debug_dos, "\tenv size: %d at $%04x\n", env_size, env_mcb + 1);
+        debug(debug_dos, "\tenv size: %d at $%04x\n", env_size, (unsigned)(env_mcb + 1));
     }
 
     // Fill MCB owners:
@@ -829,7 +829,7 @@ int dos_load_exe(FILE *f, uint16_t psp_mcb)
     int extra_bytes = g16(buf + 2);
     if(data_blocks & 0xF800)
     {
-        debug(debug_dos, "\tinvalid number of blocks ($%04x), fixing.\n", data_blocks);
+        debug(debug_dos, "\tinvalid number of blocks ($%04x), fixing.\n", (unsigned)data_blocks);
         data_blocks &= 0x07FF;
     }
     int data_size = data_blocks * 512 - head_size;
@@ -852,7 +852,8 @@ int dos_load_exe(FILE *f, uint16_t psp_mcb)
     }
 
     debug(debug_dos, "\texe: bin=%04x min=%04x max=%04x, alloc %04x segments of memory\n",
-          exe_sz, g16(buf + 10), g16(buf + 12), mcb_size(psp_mcb));
+          (unsigned)exe_sz, (unsigned)g16(buf + 10),
+          (unsigned)g16(buf + 12), (unsigned)mcb_size(psp_mcb));
 
     // Fill top program address in PSP
     put16(psp_mcb * 16 + 16 + 2, psp_mcb + mcb_size(psp_mcb) + 1);
@@ -875,8 +876,8 @@ int dos_load_exe(FILE *f, uint16_t psp_mcb)
     // EXE start at load address
     int start = load_seg * 16;
     // PSP located just 0x100 bytes before
-    debug(debug_dos, "\tPSP location: $%04X\n", psp_mcb + 1);
-    debug(debug_dos, "\tEXE start:    $%04X\n", start >> 4);
+    debug(debug_dos, "\tPSP location: $%04X\n", (unsigned)(psp_mcb + 1));
+    debug(debug_dos, "\tEXE start:    $%04X\n", (unsigned)(start >> 4));
 
     // Get segment values
     cpuSetSS((load_seg + g16(buf + 14)) & 0xFFFF);

--- a/src/timer.c
+++ b/src/timer.c
@@ -147,7 +147,7 @@ uint8_t port_timer_read(uint16_t port)
     }
 
     debug(debug_int, "timer port read $%02x = %02x (mode=%02x, r_state=%d, latch=%d)\n",
-          port, ret, t->op_mode, t->rd_mode, t->latched);
+          port, (unsigned)ret, t->op_mode, t->rd_mode, t->latched);
 
     return ret;
 }

--- a/src/video.c
+++ b/src/video.c
@@ -83,13 +83,13 @@ static void term_get_size(void)
             term_sx = 240;
         if(term_sy > 64)
             term_sy = 64;
-        debug(debug_video, "terminal size: %dx%d\n", term_sx, term_sy);
+        debug(debug_video, "terminal size: %ux%u\n", term_sx, term_sy);
     }
     else
     {
         term_sx = 80;
         term_sy = 25;
-        debug(debug_video, "can't get terminal size, assuming %dx%d\n", term_sx, term_sy);
+        debug(debug_video, "can't get terminal size, assuming %ux%u\n", term_sx, term_sy);
     }
 }
 
@@ -211,7 +211,7 @@ static void exit_video(void)
     fputs("\x1b[?7h", tty_file); // Re-enable margin
     fputs("\x1b[m", tty_file);
     fclose(tty_file);
-    debug(debug_video, "exit video - row %d\n", max);
+    debug(debug_video, "exit video - row %u\n", max);
 }
 
 static void init_video(void)
@@ -261,7 +261,7 @@ static void vid_set_font(int lines)
         rows = 64;
     else if(rows < 12)
         rows = 12;
-    debug(debug_video, "set %d lines mode from %d\n", rows, max);
+    debug(debug_video, "set %u lines mode from %u\n", rows, max);
 
     // Clear end-of-screen if we are reducing the height
     if(video_active() && max > rows)
@@ -356,7 +356,7 @@ static void term_goto_xy(unsigned x, unsigned y)
     }
     if(term_posy > y)
     {
-        fprintf(tty_file, "\x1b[%dA", term_posy - y);
+        fprintf(tty_file, "\x1b[%uA", term_posy - y);
         term_posy = y;
     }
     if(x != term_posx)
@@ -364,7 +364,7 @@ static void term_goto_xy(unsigned x, unsigned y)
         if(term_posx != 0)
             putc('\r', tty_file);
         if(x != 0)
-            fprintf(tty_file, "\x1b[%dC", x);
+            fprintf(tty_file, "\x1b[%uC", x);
         term_posx = x;
     }
 }
@@ -408,7 +408,7 @@ static void debug_screen(void)
             buf[x] = cell.chr;
         }
         buf[vid_sx] = 0;
-        debug(debug_video, "%02d: %s\n", y, buf);
+        debug(debug_video, "%02u: %s\n", y, buf);
     }
     free(buf);
 }
@@ -512,7 +512,7 @@ static void vid_scroll_up(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, int n,
 static void vid_scroll_dwn(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, unsigned n,
                            int page)
 {
-    debug(debug_video, "scroll down %d: (%d, %d) - (%d, %d)\n", n, x0, y0, x1, y1);
+    debug(debug_video, "scroll down %u: (%d, %d) - (%d, %d)\n", n, x0, y0, x1, y1);
     debug_screen();
 
     // Check parameters
@@ -623,8 +623,8 @@ void video_putch(char ch)
     if(!video_initialized)
         init_video();
     reload_posxy(vid_page);
-    debug(debug_video, "putchar %02x at (%d,%d)\n", ch & 0xFF, vid_posx[vid_page],
-          vid_posy[vid_page]);
+    debug(debug_video, "putchar %02x at (%u,%u)\n", (unsigned)(ch & 0xFF),
+          vid_posx[vid_page], vid_posy[vid_page]);
     video_putchar(ch, 0xFF00, vid_page);
 }
 
@@ -814,14 +814,14 @@ void intr10()
             }
             else
             {
-                debug(debug_video, "UNHANDLED INT 10, AH=12 BL=%02x\n", bl);
+                debug(debug_video, "UNHANDLED INT 10, AH=12 BL=%02x\n", (unsigned)bl);
                 break;
             }
             // Return OK
             cpuSetAX(0x1212);
         }
         else
-            debug(debug_video, "UNHANDLED INT 10, AH=12 BL=%02x\n", bl);
+            debug(debug_video, "UNHANDLED INT 10, AH=12 BL=%02x\n", (unsigned)bl);
     }
     break;
     case 0x13: // WRITE STRING


### PR DESCRIPTION
Silence Clang’s extended `-Wformat` warnings:

```c
src/loader.c:408:79: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:409:29: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:409:36: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:549:66: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:549:71: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:651:65: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:832:75: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:855:11: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:855:19: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:855:34: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:855:49: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:878:49: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/loader.c:879:49: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dis.c:63:81: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dis.c:73:81: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dis.c:140:42: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dis.c:140:63: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dis.c:377:13: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:137:40: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/dos.c:161:40: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/dos.c:210:63: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:285:41: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:285:61: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:286:31: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:309:67: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:476:44: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/dos.c:494:48: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/dos.c:807:63: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1007:11: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1007:23: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1007:31: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1007:39: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1007:47: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1007:55: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1007:63: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1711:44: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1778:58: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1806:49: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/dos.c:1818:56: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1824:77: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1848:65: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:1929:15: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:2284:69: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:2422:41: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/dos.c:2423:61: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/keyb.c:508:69: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/timer.c:150:17: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/video.c:86:54: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:86:63: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:92:73: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:92:82: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:214:49: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:264:55: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:264:61: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:359:39: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:367:43: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:411:42: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:515:65: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:626:53: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/video.c:626:64: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:627:11: warning: format specifies type 'int' but the argument has type 'unsigned int' [-Wformat]
src/video.c:817:73: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
src/video.c:824:69: warning: format specifies type 'unsigned int' but the argument has type 'int' [-Wformat]
```