### PR TITLE
Recursively remove (`rm -rf`) the `obj` directory during `make clean`

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,9 +31,8 @@ obj:
 
 .PHONY: clean distclean
 clean distclean:
-	rm -f $(OBJS:%=obj/%)
+	rm -rf obj
 	rm -f emu2
-	test -d obj && rmdir obj || true
 
 .PHONY: install
 install: emu2


### PR DESCRIPTION
Recursively remove (`rm -rf`) the `obj` directory during `make clean`

This was part of #73, not sure if you didn't want it or if it was inadvertently left out.

Feel free to just close if it's not wanted.