### PR TITLE
Silence Oracle Studio `attribute "format" is unknown` warnings

### DIFF
--- a/src/dbg.c
+++ b/src/dbg.c
@@ -1,6 +1,8 @@
 #include "dbg.h"
 #include "env.h"
 #include "version.h"
+#include "os.h"
+
 #include <fcntl.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -52,7 +54,8 @@ void print_usage(void)
     exit(EXIT_SUCCESS);
 }
 
-void print_usage_error(const char *format, ...)
+PRINTF_FORMAT_ATTR(1, 2)
+void print_usage_error(PRINTF_FORMAT const char *format, ...)
 {
     va_list ap;
     fprintf(stderr, "%s: ", prog_name);
@@ -63,7 +66,8 @@ void print_usage_error(const char *format, ...)
     exit(EXIT_FAILURE);
 }
 
-void print_error(const char *format, ...)
+PRINTF_FORMAT_ATTR(1, 2)
+void print_error(PRINTF_FORMAT const char *format, ...)
 {
     va_list ap;
     fprintf(stderr, "%s: ", prog_name);
@@ -115,7 +119,8 @@ int debug_active(enum debug_type dt)
         return 0;
 }
 
-void debug(enum debug_type dt, const char *format, ...)
+PRINTF_FORMAT_ATTR(2, 3)
+void debug(enum debug_type dt, PRINTF_FORMAT const char *format, ...)
 {
     va_list ap;
     if(debug_active(dt))

--- a/src/dbg.h
+++ b/src/dbg.h
@@ -6,8 +6,8 @@ extern char *prog_name;
 
 void print_version(int quit);
 void print_usage(void);
-void print_usage_error(const char *format, ...) __attribute__((format(printf, 1, 2)));
-void print_error(const char *format, ...) __attribute__((format(printf, 1, 2)));
+void print_usage_error(const char *format, ...);
+void print_error(const char *format, ...);
 
 enum debug_type
 {
@@ -20,6 +20,5 @@ enum debug_type
 };
 
 void init_debug(const char *name);
-void debug(enum debug_type, const char *format, ...)
-    __attribute__((format(printf, 2, 3)));
+void debug(enum debug_type, const char *format, ...);
 int debug_active(enum debug_type);

--- a/src/os.h
+++ b/src/os.h
@@ -1,6 +1,24 @@
 #ifndef OS_H_INCLUDED
 #define OS_H_INCLUDED
 
+/* Detect proper "format" annotation */
+#if defined(_MSC_VER) && !defined(__clang__)
+# include <stddef.h>
+# undef _USE_ATTRIBUTES_FOR_SAL
+# define _USE_ATTRIBUTES_FOR_SAL 1
+# include <sal.h>
+# define PRINTF_FORMAT _Printf_format_string_
+# define PRINTF_FORMAT_ATTR(fmt_p, va_p)
+#else
+# define PRINTF_FORMAT
+# if !defined(__SUNPRO_C) && !defined(__SUNPRO_CC)
+#  define PRINTF_FORMAT_ATTR(fmt_p, va_p) \
+   __attribute__((format (printf, fmt_p, va_p)))
+# else
+#  define PRINTF_FORMAT_ATTR(fmt_p, va_p)
+#  endif
+#endif
+
 /* Platforms which are missing cfmakeraw() */
 #if defined(__sun)
 # if !defined(NO_CFMAKERAW)


### PR DESCRIPTION
Silence Oracle Studio `attribute "format" is unknown` warnings which are produced when compiling every file when using the Oracle Studio C/C++ compilers on any platform (Linux, Solaris, illumos):

```sh
[ ... snip ... ]
suncc -O3 -c -o obj/dbg.o src/dbg.c
"src/dbg.h", line 9: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 10: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 24: warning: attribute "format" is unknown, ignored
suncc -O3 -c -o obj/timer.o src/timer.c
"src/dbg.h", line 9: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 10: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 24: warning: attribute "format" is unknown, ignored
suncc -O3 -c -o obj/utils.o src/utils.c
"src/dbg.h", line 9: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 10: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 24: warning: attribute "format" is unknown, ignored
suncc -O3 -c -o obj/video.o src/video.c
"src/dbg.h", line 9: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 10: warning: attribute "format" is unknown, ignored
"src/dbg.h", line 24: warning: attribute "format" is unknown, ignored
[ ... snip ... ]
```

Behavior with existing compilers is unchanged (GCC, Clang, XLC, NVC, etc).

This change also supports MSVC (even though the rest of the project doesn't, at least not yet.)