### PR TITLE
Create `platform.mk` for platform-specific build configuation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,8 +1,11 @@
+SHELL=/bin/sh
 CC?=cc
-CFLAGS?=-O3 -flto -Wall -g -Werror=implicit-function-declaration -Werror=int-conversion
+CFLAGS?=-O3 -g
 LDLIBS?=-lm
 INSTALL?=install
 PREFIX?=/usr
+
+include platform.mk
 
 OBJS=\
  cpu.o\
@@ -22,7 +25,7 @@ OBJS=\
 all: obj emu2
 
 emu2: $(OBJS:%=obj/%)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+	$(CC) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 obj/%.o: src/%.c
 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/platform.mk
+++ b/platform.mk
@@ -1,0 +1,75 @@
+# Determine if CC is GCC or Clang
+TGCLT:=$(shell $(CC) --version 2>&1 | grep -q -i -e 'clang' -e 'gcc' && \
+         printf '%s\n' "1" || printf '%s\n' "0")
+ifeq "$(TGCLT)" "1"
+ GCC_CL=1
+endif
+
+# If CC is GCC or Clang, use extra warning flags
+EXTRA_CFLAGS := -Wall -Werror=implicit-function-declaration -Werror=int-conversion
+ifeq "$(GCC_CL)" "1"
+ CFLAGS += $(EXTRA_CFLAGS)
+endif
+
+# Determine LTO invocation: Try `-flto=auto`, fall back to `-ftlo`
+LTOSYN:=$(shell $(CC) -flto=auto -E - < /dev/null > /dev/null 2>&1 && \
+         printf '%s\n' "-flto=auto" || printf '%s\n' "-flto")
+ifeq "$(findstring xlc,$(CC))" ""
+ ifeq "$(findstring nvc,$(CC))" ""
+  ifeq "$(findstring suncc,$(CC))" ""
+   ifeq "$(findstring clang,$(CC))" ""
+    ifeq "$(findstring gcc,$(CC))" ""
+     ifeq "$(findstring icc,$(CC))" ""
+      # Others? try LTO
+      CFLAGS += $(LTOSYN)
+      LDFLAGS += $(LTOSYN)
+     else
+      # Intel C Compiler Classic: use IPO
+      CFLAGS += -ipo -diag-disable=10440
+      LDFLAGS += -ipo -diag-disable=10440
+     endif
+    else
+     # GCC
+     CFLAGS += $(LTOSYN)
+     LDFLAGS += $(LTOSYN)
+    endif
+   else
+    # Clang
+    CFLAGS += $(LTOSYN) -Wno-ignored-optimization-argument
+    LDFLAGS += $(LTOSYN) -Wno-ignored-optimization-argument
+   endif
+  else
+   # Oracle Studio: no LTO
+  endif
+ else
+  # NVIDIA HPC SDK: no LTO
+ endif
+else
+ # IBM XLC (V16): no LTO
+endif
+
+# Solaris or illumos: Force `-flto=auto` to `-flto`
+ifneq "$(findstring SunOS,$(shell uname -s 2> /dev/null))" ""
+ CFLAGS := $(subst -flto=auto,-flto,$(CFLAGS))
+ LDFLAGS := $(subst -flto=auto,-flto,$(LDFLAGS))
+endif
+
+# AIX with GCC: no LTO
+ifneq "$(findstring AIX,$(shell uname -s 2> /dev/null))" ""
+ ifneq "$(findstring gcc,$(CC))" ""
+  CFLAGS := $(subst -flto=auto,-flto,$(CFLAGS))
+  CFLAGS := $(subst -flto,,$(CFLAGS))
+  LDFLAGS := $(subst -flto=auto,-flto,$(LDFLAGS))
+  LDFLAGS := $(subst -flto,,$(LDFLAGS))
+ endif
+endif
+
+# OS/400 with GCC: no LTO
+ifneq "$(findstring OS400,$(shell uname -s 2> /dev/null))" ""
+ ifneq "$(findstring gcc,$(CC))" ""
+  CFLAGS := $(subst -flto=auto,-flto,$(CFLAGS))
+  CFLAGS := $(subst -flto,,$(CFLAGS))
+  LDFLAGS := $(subst -flto=auto,-flto,$(LDFLAGS))
+  LDFLAGS := $(subst -flto,,$(LDFLAGS))
+ endif
+endif

--- a/platform.mk
+++ b/platform.mk
@@ -11,6 +11,9 @@ ifeq "$(GCC_CL)" "1"
  CFLAGS += $(EXTRA_CFLAGS)
 endif
 
+# Determine OS via `uname -s`
+UNAME_S:=$(shell uname -s 2> /dev/null)
+
 # Determine LTO invocation: Try `-flto=auto`, fall back to `-ftlo`
 LTOSYN:=$(shell $(CC) -flto=auto -E - < /dev/null > /dev/null 2>&1 && \
          printf '%s\n' "-flto=auto" || printf '%s\n' "-flto")
@@ -49,13 +52,13 @@ else
 endif
 
 # Solaris or illumos: Force `-flto=auto` to `-flto`
-ifneq "$(findstring SunOS,$(shell uname -s 2> /dev/null))" ""
+ifneq "$(findstring SunOS,$(UNAME_S))" ""
  CFLAGS := $(subst -flto=auto,-flto,$(CFLAGS))
  LDFLAGS := $(subst -flto=auto,-flto,$(LDFLAGS))
 endif
 
 # AIX with GCC: no LTO
-ifneq "$(findstring AIX,$(shell uname -s 2> /dev/null))" ""
+ifneq "$(findstring AIX,$(UNAME_S))" ""
  ifneq "$(findstring gcc,$(CC))" ""
   CFLAGS := $(subst -flto=auto,-flto,$(CFLAGS))
   CFLAGS := $(subst -flto,,$(CFLAGS))
@@ -65,7 +68,7 @@ ifneq "$(findstring AIX,$(shell uname -s 2> /dev/null))" ""
 endif
 
 # OS/400 with GCC: no LTO
-ifneq "$(findstring OS400,$(shell uname -s 2> /dev/null))" ""
+ifneq "$(findstring OS400,$(UNAME_S))" ""
  ifneq "$(findstring gcc,$(CC))" ""
   CFLAGS := $(subst -flto=auto,-flto,$(CFLAGS))
   CFLAGS := $(subst -flto,,$(CFLAGS))


### PR DESCRIPTION
Apply some heuristics to determine (without the need for user interaction) a build configuration to compile optimally by just invoking `make`, and all without interfering with cross-compiled builds.

This also (*portably*) silences any `lto-wrapper` LTRANS warnings.

This is done automatically and using only GNU Make and POSIX-conforming shell utilities (`printf`, `uname`, and `grep`).

- Determine if `CC` is *Clang* or *GCC* (by checking the output of “`--version`”, and if it is, use extra warning flags, defined in “`EXTRA_CFLAGS`”.

- Determines if “`-flto=auto`” is invalid, and if so, assumes “`-flto`” should be used instead. \
\
This is done by invoking the compiler frontend in preprocessor mode and passing the flag.  This is not foolproof, but it is fast, and it doesn't require compiling any actual code and handling the output.

  - If `CC` contains “`icc`" (*Intel C Compiler Classic*), enable IPO.

  - If `CC` contains "`suncc`" (*Oracle Developer Studio*), "`nvc`" (*NVIDIA HPC SDK*), or "`xlc`" (*IBM XL C/C++ <=16*), disable LTO.

  - Disables LTO when using *GCC* on *IBM AIX* or *IBM OS/400*.

  - Always use "`-flto`" for LTO on *Solaris* or *illumos* systems.

---

This is a draft while I do some more testing.  Also, if you decide to take any of the other changes in pending PRs, this will likely need to be rebased anyway.