### PR TITLE
Suppress a false positive warning from `nvc` and `pgcc`

### DIFF
--- a/src/dos.c
+++ b/src/dos.c
@@ -2076,7 +2076,8 @@ void intr21(void)
         break;
     case 0x65: // GET NLS DATA
     {
-        uint32_t addr = cpuGetAddrES(cpuGetDI());
+        uint32_t addr;
+        addr = cpuGetAddrES(cpuGetDI());
         cpuClrFlag(cpuFlag_CF);
         switch(ax & 0xFF)
         {


### PR DESCRIPTION
Suppress a false positive warning from `nvc` (NVIDIA HPC SDK C) and `pgcc` (Portland Group C Compiler):

```c
"src/dos.c", line 1096: warning: transfer of control bypasses initialization of: [branch_past_initialization]
            variable "addr" (declared at line 2079)
      switch(ah)
      ^
```