### PR TITLE
Silence some warnings from Oracle Developer Studio C/C++

### DIFF
--- a/src/codepage.c
+++ b/src/codepage.c
@@ -238,10 +238,9 @@ static int read_codepage_file(const char *fname)
             if(dcode < 0 || dcode > 256)
             {
                 fclose(f);
+                free(new_table);
                 print_error("reading codepage '%s', line '%s', invalid byte value %d\n",
                             fname, line, dcode);
-                free(new_table);
-                return 0;
             }
             // Ignore control-codes
             if(dcode < 32 || dcode == 127)
@@ -249,11 +248,10 @@ static int read_codepage_file(const char *fname)
             if(ucode < 32 || ucode > 0xFFFF)
             {
                 fclose(f);
+                free(new_table);
                 print_error(
                     "reading codepage '%s', line '%s', invalid unicode value %d\n", fname,
                     line, ucode);
-                free(new_table);
-                return 0;
             }
             new_table[dcode] = ucode;
         }

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -2535,7 +2535,7 @@ static void do_instruction(uint8_t code)
     case 0xf1: i_undefined();                                  break;
     case 0xf2: rep(0);                                         break;
     case 0xf3: rep(1);                                         break;
-    case 0xf4: i_halt();                                       break;
+    case 0xf4: i_halt();
     case 0xf5: CF = !CF;                                       break;
     case 0xf6: i_f6pre();                                      break;
     case 0xf7: i_f7pre();                                      break;

--- a/src/dos.c
+++ b/src/dos.c
@@ -534,7 +534,6 @@ static struct find_first_dta *get_find_first_dta(void)
         if(i == NUM_FIND_FIRST_DTA)
         {
             print_error("Too many find-first DTA areas opened\n");
-            i = 0;
         }
         find_first_dta[i].dta_addr = dosDTA;
         find_first_dta[i].find_first_list = 0;
@@ -810,7 +809,6 @@ static int run_emulator(char *file, const char *prgname, char *cmdline, char *en
             if(errno != EINTR)
             {
                 print_error("error waiting child, %s\n", strerror(errno));
-                break;
             }
         }
         return_code = (WEXITSTATUS(status) & 0xFF);

--- a/src/keyb.c
+++ b/src/keyb.c
@@ -409,7 +409,6 @@ static void init_keyboard(void)
         if(tty_fd < 0)
         {
             print_error("error at open TTY, %s\n", strerror(errno));
-            exit(1);
         }
         atexit(exit_keyboard);
     }

--- a/src/video.c
+++ b/src/video.c
@@ -221,13 +221,11 @@ static void init_video(void)
     if(tty_fd < 0)
     {
         print_error("error at open TTY, %s\n", strerror(errno));
-        exit(1);
     }
     tty_file = fdopen(tty_fd, "w");
     if(!tty_file)
     {
         print_error("error at open TTY, %s\n", strerror(errno));
-        exit(1);
     }
     fputs("\x1b[?7l", tty_file); // Disable automatic margin
     atexit(exit_video);


### PR DESCRIPTION
These mostly are cases of code appearing after `print_error`, which does not return:

```c

"src/cpu.c", line 2538: warning: statement not reached
"src/codepage.c", line 243: warning: statement not reached
"src/codepage.c", line 255: warning: statement not reached
"src/dos.c", line 537: warning: statement not reached
"src/dos.c", line 813: warning: statement not reached
"src/keyb.c", line 412: warning: statement not reached
"src/video.c", line 224: warning: statement not reached
"src/video.c", line 230: warning: statement not reached
```